### PR TITLE
Ash/add sampling for expressions with factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,23 @@
 # vegas_params
 Wrapper package for [Vegas](https://vegas.readthedocs.io) integrator.
 
+This package allows user to define composite expressions, which can be used to:
+1. Calculate integrals using `vegas` algorithm
+2. Make random samples of given expressions (for MC simulation apart from `vegas`)
+
 ## Installation
 
-You can install `vegas_params` via github link
+You can install `vegas_params` from PyPI:
+```shell
+pip install vegas_params
+```
+
+or directly via github link:
 ```shell
 pip install git+https://github.com/RTESolution/vegas_params.git
 ```
 
-## Examples
+## Quickstart
 ### Gaussian integral
 Let's caluclate integral 
 $$
@@ -20,9 +29,10 @@ $$
 
 Here is how you can do it:
 ```python
-@integral   
-@expression(x=Uniform([-1000,1000]),
-            y=Uniform([-1000,1000]))
+import vegas_params as vp
+@vp.integral
+@vp.expression(x=vp.Uniform([-1000,1000]),
+            y=vp.Uniform([-1000,1000]))
 def gaussian(x, y):
     return np.exp(-(x**2+y**2))
 ```
@@ -30,4 +40,46 @@ Now `gaussian` is a callable, where you can pass the parameters of the vegas int
 ```python
 gaussian(nitn=20, neval=100000)
 #3.13805(16) - close to expected Pi
+```
+
+## Defining expressions
+
+### Basic parameters
+There are basic types of expressions:
+```python
+#fixed value:
+c = vp.Fixed(299792458) #speed of light in vacuum in m/s
+#uniform value, that will be integrated over
+cos_theta = vp.Uniform([-1,1]) #cos_theta is in the given range
+```
+
+### Compound expressions
+Other expressions can be defined from these components.
+
+More complex expressions can be defined using `vp.Expression` class or `vp.expression` decorator:
+
+```python
+@vp.expression
+def product(x,y):
+    return x*y
+    
+```
+
+It's possible to also add the Jacobian factor to the expression. 
+To do this, add `self` argument to function and set `serlf.factor` to needed value. This value will be multiplied by the expression value during the integration.
+
+## Sampling
+
+The `vegas_params` expressions and parameters can be used not only for integration, but as random value generators.
+
+You can ask an expression to generate a sample of given size:
+```python
+data = expr.sample(size=1000)
+```
+
+If your expression, or it's components (the expression parameters, provided in constructor) define the `factor`, then a simple `sample` method will not take it into account.
+
+You need to use `sample_with_factor` method, which will iteratively generate samples and filter them, by randomly discarding the samples according to their `factor` values:
+```python
+data = expr.sample_with_factor(size=1000)
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ data['x']
 #array([-0.04495105])
 ```
 
-### General compund expressions with `expression` decorator
+### 3.4 General compund expressions with `expression` decorator
 Other expressions can be defined from these components.
 
 More complex expressions can be defined using `vp.Expression` class or `vp.expression` decorator:
@@ -97,6 +97,7 @@ To do this, add `self` argument to function and set `serlf.factor` to needed val
 
 The `vegas_params` expressions and parameters can be used not only for integration, but as random value generators.
 
+## 4.1. Sampling without factor
 You can ask an expression to generate a sample of given size:
 ```python
 data = expr.sample(size=1000)
@@ -104,7 +105,11 @@ data = expr.sample(size=1000)
 
 If your expression, or it's components (the expression parameters, provided in constructor) define the `factor`, then a simple `sample` method will not take it into account.
 
-You need to use `sample_with_factor` method, which will iteratively generate samples and filter them, by randomly discarding the samples according to their `factor` values:
+## 4.2 Sampling with factor
+
+In case you want to get a sample which is distributed according to the expression's `factor`, you need to use `sample_with_factor` method, which will iteratively generate samples and filter them, by randomly discarding the samples according to their `factor` values:
 ```python
 data = expr.sample_with_factor(size=1000)
 ```
+
+Note that this method is iterative and much slower that `sample` method.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package allows user to define composite expressions, which can be used to:
 1. Calculate integrals using `vegas` algorithm
 2. Make random samples of given expressions (for MC simulation apart from `vegas`)
 
-## Installation
+## 1. Installation
 
 You can install `vegas_params` from PyPI:
 ```shell
@@ -20,8 +20,7 @@ or directly via github link:
 pip install git+https://github.com/RTESolution/vegas_params.git
 ```
 
-## Quickstart
-### Gaussian integral
+## 2. Quickstart
 Let's caluclate integral 
 $$
 \int\limits_{-1000}^{1000}dx \int\limits_{-1000}^{1000}dy \; e^{-(x^2+y^2)}
@@ -42,9 +41,10 @@ gaussian(nitn=20, neval=100000)
 #3.13805(16) - close to expected Pi
 ```
 
-## Defining expressions
+## 3. Defining expressions
 
-### Basic parameters
+
+### 3.1 Basic parameters
 There are basic types of expressions:
 ```python
 #fixed value:
@@ -52,8 +52,33 @@ c = vp.Fixed(299792458) #speed of light in vacuum in m/s
 #uniform value, that will be integrated over
 cos_theta = vp.Uniform([-1,1]) #cos_theta is in the given range
 ```
+### 3.2 Concatenating parameters: `collections.Concat`
+It's possible to concatenate the parameters using `vp.collections.Concat`:
+```python
+#say we want to define 3 coordinates with different limits: x in [-1,1], y in [0,10] and z fixed to 0
+xyz = vp.collections.Concat(vp.Uniform([-1,1]), vp.Uniform([0,10]), vp.Fixed(0))
+xyz.sample(1)
+# array([[-0.67329745,  5.77401635,  0.        ]])
+```
+Same concatenation can be done with `|` operator. Also `Fixed` can be omitted:
+```python
+#equivalent to above
+xyz = vp.Uniform([-1,1])|vp.Uniform([0,10])|0
+xyz.sample(1)
+#array([[-0.20342379,  0.7356486 ,  0.        ]])
+```
+### 3.3 Producing structured array with `collections.StructArray`
+It's possible to make a [numpy.structured_array](https://numpy.org/doc/stable/user/basics.rec.html#structured-arrays) from given parameters:
+```python
+xyz = vp.collections.StructArray(x=vp.Uniform([-1,1]), y=vp.Uniform([0,10]), z=0)
+data = xyz.sample(1)
+#array(([-0.04495105], [1.97159299], [0.]),
+# dtype=[('x', '<f8', (1,)), ('y', '<f8', (1,)), ('z', '<f8', (1,))])
+data['x']
+#array([-0.04495105])
+```
 
-### Compound expressions
+### General compund expressions with `expression` decorator
 Other expressions can be defined from these components.
 
 More complex expressions can be defined using `vp.Expression` class or `vp.expression` decorator:
@@ -68,7 +93,7 @@ def product(x,y):
 It's possible to also add the Jacobian factor to the expression. 
 To do this, add `self` argument to function and set `serlf.factor` to needed value. This value will be multiplied by the expression value during the integration.
 
-## Sampling
+## 4. Sampling
 
 The `vegas_params` expressions and parameters can be used not only for integration, but as random value generators.
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 from . import base, vector, collections, sampling
 from .base import Uniform, Fixed, FromDistribution, Expression, expression
 from .vector import Direction, Vector, Scalar

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.1.0"
-from . import base, vector, collections
+from . import base, vector, collections, sampling
 from .base import Uniform, Fixed, FromDistribution, Expression, expression
 from .vector import Direction, Vector, Scalar
 from .integration import integral

--- a/src/base.py
+++ b/src/base.py
@@ -22,7 +22,7 @@ class Parameter(abc.ABC):
                               self.input_limits[:,1], 
                               size=[size,len(self)])
         values = self.__construct__(x)
-        self.factor*=np.ones(size) #make sure the factor is array of size len(sample)
+        #self.factor*=np.ones(size) #make sure the factor is array of size len(sample)
         return values
         
     def sample_with_factor(self, size=1, iter_max=10):
@@ -36,6 +36,7 @@ class Parameter(abc.ABC):
         the_factor = self.factor
         the_random = np.empty_like(the_factor)
         selected = []
+        N = size
         N_generate = int(N*2) #the size of next sample to generate
         for it in range(iter_max):
             sample, factor = self.sample(N_generate), self.factor
@@ -167,18 +168,8 @@ class FromDistribution(Expression):
     def __pow__(self, n:int):
         return self.__class__(self.ppf, len(self)*n)
 
-#define the decorators
-def expression_from_callable(**parameters):
-    """decorator for creating the Expression from function"""
-    def _wrapper(obj):
-        c = Expression(**parameters)
-        c.__name__ = obj.__name__
-        c.__qualname__ = obj.__qualname__
-        c.__call__ = obj
-        return c
-    return _wrapper
 
-def expression_from_class(c):
+def _expression_from_class(c):
     """A class decorator to make an Expression class"""
     #prepare the signature
     params = [inspect.Parameter(name=name, 
@@ -199,42 +190,49 @@ def expression_from_class(c):
             params = S.bind(*args, **kwargs)
             params.apply_defaults()
             Expression.__init__(self, **params.arguments)
-    #fill the class and module name to be the same as in class
-    c1.__qualname__ = c.__qualname__
-    c1.__name__ = c.__name__
-    c1.__module__ = c.__module__
     c1.__signature__ = S
     return c1
 
 def expression(obj=None, **parameters):
     """A decorator to create expression classes from functions or classes."""
     if obj is None:
-        return expression_from_callable(**parameters)
-    
+        #no object (class or callable) was passed, so let's delegate this to the next layer
+        def _make_expression(the_obj):
+            return expression(the_obj, **parameters)
+        return _make_expression
+        
     if inspect.isclass(obj):
-        return expression_from_class(obj)
+        cls = _expression_from_class(obj)
+        
     elif isinstance(obj, Callable):
         #make a class and wrap it
         S = inspect.signature(obj)
-        parameters = list(S.parameters)
-        if parameters[0]=='self':
-            del parameters[0]
+        arguments = list(S.parameters)
+        if arguments[0]=='self':
+            del arguments[0]
             make_function = obj
         else:
             make_function = staticmethod(obj)
-        class c:
+        class C:
             #check if a first argument is "self"
             __call__=make_function
         #set parameters
-            
-        c.__annotations__ = {name:Parameter for name in parameters}
-        c.__qualname__ = obj.__qualname__
-        c.__doc__ = obj.__doc__
-        c.__name__ = obj.__name__
-        c.__module__ = obj.__module__
-        return expression_from_class(c)
+        
+        C.__annotations__ = {name:Parameter for name in arguments}
+
+        cls = _expression_from_class(C)
     else:
         raise TypeError(f"`obj` must be a class or a function, not a {obj.__class__.__name__}")
+
+    #fill the class and module name to be the same as in class
+    cls.__qualname__ = obj.__qualname__
+    cls.__name__ = obj.__name__
+    cls.__module__ = obj.__module__
+    cls.__doc__ = obj.__doc__
+    if parameters=={}:
+        return cls
+    else:
+        return cls(**parameters)
 
 def forward_input(func):
     """A function decorator to return the dict of input arguments alongside with the function result"""

--- a/src/base.py
+++ b/src/base.py
@@ -21,9 +21,11 @@ class Parameter(abc.ABC):
         x = np.random.uniform(self.input_limits[:,0],
                               self.input_limits[:,1], 
                               size=[size,len(self)])
-        return self.__construct__(x)
+        values = self.__construct__(x)
+        self.factor*=np.ones(size) #make sure the factor is array of size len(sample)
+        return values
         
-    def sample_with_factor(self, N=1, iter_max=10):
+    def sample_with_factor(self, size=1, iter_max=10):
         """Generate a random sample of this expression values, 
         taking into account the factor as the probability density.
 
@@ -41,8 +43,7 @@ class Parameter(abc.ABC):
                 if np.min(self.factor)==np.max(self.factor):
                     #the factor is equal for all values, so just return this sample
                     return sample[:N]
-                
-            factor*=np.ones(len(sample)) #make sure the factor is array of size len(sample)
+                    
             random = np.random.uniform(size=len(sample))
             the_sample = np.append(the_sample, sample, axis=0)
             the_factor = np.append(the_factor, factor, axis=0)

--- a/src/base.py
+++ b/src/base.py
@@ -198,5 +198,7 @@ def forward_input(func):
 Shifted = expression(lambda v,shift: v+shift)
 Scaled = expression(lambda v,factor: v*factor)
 
+Parameter.__add__ = lambda self,other: Shifted(self,other)
+Parameter.__radd__ = lambda self,other: Shifted(other, self)
 Parameter.__mul__ = lambda x,y:Scaled(x,y)
 Parameter.__rmul__ = lambda x,y:Scaled(y,x)

--- a/src/base.py
+++ b/src/base.py
@@ -192,7 +192,10 @@ def _expression_from_class(c):
     S = inspect.signature(c.__call__)
     arguments = list(S.parameters)
     if arguments[0]=='self':
-        del arguments[0]    
+        del arguments[0]  
+    #for python<3.10 class doesn't have __annotations__ by default
+    if not hasattr(c, '__annotatations__'):
+        c.__annotations__ = {}
     #prepare the signature
     params = [inspect.Parameter(name=name, 
                                 kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,

--- a/src/base.py
+++ b/src/base.py
@@ -22,6 +22,49 @@ class Parameter(abc.ABC):
                               self.input_limits[:,1], 
                               size=[size,len(self)])
         return self.__construct__(x)
+        
+    def sample_with_factor(self, N=1, iter_max=10):
+        """Generate a random sample of this expression values, 
+        taking into account the factor as the probability density.
+
+        Note: this process is iterative (it might need to generate several samples), and several times slower than regular :meth:`sample` method
+        """
+        #start with the sample of size N
+        the_sample = self.sample(0) #just get the output size
+        the_factor = self.factor
+        the_random = np.empty_like(the_factor)
+        selected = []
+        N_generate = int(N*2) #the size of next sample to generate
+        for it in range(iter_max):
+            sample, factor = self.sample(N_generate), self.factor
+            if it==0:
+                if np.min(self.factor)==np.max(self.factor):
+                    #the factor is equal for all values, so just return this sample
+                    return sample[:N]
+                
+            factor*=np.ones(len(sample)) #make sure the factor is array of size len(sample)
+            random = np.random.uniform(size=len(sample))
+            the_sample = np.append(the_sample, sample, axis=0)
+            the_factor = np.append(the_factor, factor, axis=0)
+            the_random = np.append(the_random, random, axis=0)
+            #apply the selection
+            selected = (the_random*the_factor.max()) < the_factor
+            N_selected = selected.sum()
+            print(f"Iteration #{it}: generated {N_generate} -> selected={N_selected}/{len(the_factor)}")
+            if N_selected>=N:
+                return the_sample[selected][:N]
+            else:
+                prob = N_selected/len(the_sample) #estimated selection probability
+                #now decide how many items to generate
+                # N = prob*(N_total) = N_selected + prob*N_generate =>
+                N_generate = (N-N_selected)/prob
+                #additional 20% to avoid making small iterations
+                N_generate *= 1.2
+                #make sure we don't make a sample too small or too large
+                N_generate = np.clip(N_generate, N/100, N*1000)
+                N_generate = np.asarray(np.ceil(N_generate), dtype=int)
+        raise RuntimeError(f"Maximum iterations ({iter_max}) reached. Generated only {sum(selected)} points of {N} requested")
+
 
 class Fixed(Parameter):
     """Fixed value, not a part of integration"""

--- a/src/base.py
+++ b/src/base.py
@@ -54,8 +54,9 @@ class Parameter(abc.ABC):
             #apply the selection
             selected = (the_random*the_factor.max()) < the_factor
             N_selected = selected.sum()
-            print(f"Iteration #{it}: generated {N_generate} -> selected={N_selected}/{len(the_factor)}")
+            # print(f"Iteration #{it}: generated {N_generate} -> selected={N_selected}/{len(the_factor)}")
             if N_selected>=N:
+                self.factor = np.ones(N)*N/len(the_factor)
                 return the_sample[selected][:N]
             else:
                 prob = N_selected/len(the_sample) #estimated selection probability

--- a/src/base.py
+++ b/src/base.py
@@ -32,9 +32,6 @@ class Parameter(abc.ABC):
         Note: this process is iterative (it might need to generate several samples), and several times slower than regular :meth:`sample` method
         """
         #start with the sample of size N
-        the_sample = self.sample(0) #just get the output size
-        the_factor = self.factor*np.ones(shape=(0,))
-        the_random = np.empty_like(the_factor)
         selected = []
         N = size
         N_generate = int(N*2) #the size of next sample to generate
@@ -48,13 +45,18 @@ class Parameter(abc.ABC):
                     return sample[:N]
                     
             random = np.random.uniform(size=len(sample))
-            the_sample = np.append(the_sample, sample, axis=0)
-            the_factor = np.append(the_factor, factor, axis=0)
-            the_random = np.append(the_random, random, axis=0)
+            if it==0:
+                the_sample = sample
+                the_factor = factor
+                the_random = random
+            else:
+                the_sample = np.append(the_sample, sample, axis=0)
+                the_factor = np.append(the_factor, factor, axis=0)
+                the_random = np.append(the_random, random, axis=0)
             #apply the selection
             selected = (the_random*the_factor.max()) < the_factor
             N_selected = selected.sum()
-            # print(f"Iteration #{it}: generated {N_generate} -> selected={N_selected}/{len(the_factor)}")
+            print(f"Iteration #{it}: generated {N_generate} -> selected={N_selected}/{len(the_factor)}")
             if N_selected>=N:
                 self.factor = np.ones(N)*N/len(the_factor)
                 return the_sample[selected][:N]

--- a/src/collections.py
+++ b/src/collections.py
@@ -1,20 +1,42 @@
-from .base import Expression
+from .base import Expression, Parameter
 from collections import namedtuple
 from typing import Sequence
 import numpy as np
 
-    
-class ParamTuple(Expression):
-    """A class to pack your values to a tuple"""
-    def __init__(self, name:str="ParamTuple", **parameters):
-        super().__init__(**parameters)
-        self.data_class = namedtuple(name, list(parameters.keys()))
-    def make(self, *args:Sequence[np.ndarray]):
-        return self.data_class(*args)
+class Concat(Expression):
+    """Concatenate arrays along axis=1 into a single array"""
+    def __init__(self, *expressions:Sequence[Parameter]):
+        super().__init__(**{f"p_{num}":expr for num,expr in enumerate(expressions)})
+    @staticmethod
+    def __call__(*args:Sequence[np.ndarray])->np.ndarray:
+        result = np.concatenate(args,axis=1)
+        return result.view(type(args[0]))
+    def __or__(self, other):
+        #if concatenating with another Concat
+        return Concat(*list(self.parameters.values()), other)
 
-class ParamDict(Expression):
-    """A class to pack your values to a dict"""
-    def __init__(self, **parameters):
+#add the operators
+Parameter.__or__ = lambda self,other: Concat(self,other)
+Parameter.__ror__ = lambda self,other: Concat(other, self)
+Parameter.__add__ = lambda self,other: Shifted(self,other)
+Parameter.__radd__ = lambda self,other: Shifted(other, self)
+
+
+class StructArray(Expression):
+    """Conctenate arrays along given axis, and form them into a np.structured_array"""
+    def __init__(self, axis=-1, **parameters):
+        self.axis = axis
+        #initilaize as expression
         super().__init__(**parameters)
-    def make(self, **kwargs)->np.ndarray:
-        return kwargs
+        
+    def __call__(self, *args:Sequence[np.ndarray])->np.ndarray:
+        #store the formats for each argument
+        formats = []
+        for a in args:
+            a = a.squeeze(1)
+            size = a.shape[self.axis]
+            fmt = (a.dtype, size)
+            formats.append(fmt)
+        dtype = np.dtype({'names':list(self.parameters),'formats':formats})
+        result = np.concatenate(args, axis=self.axis).squeeze()
+        return result.view(dtype=dtype)

--- a/src/collections.py
+++ b/src/collections.py
@@ -18,8 +18,6 @@ class Concat(Expression):
 #add the operators
 Parameter.__or__ = lambda self,other: Concat(self,other)
 Parameter.__ror__ = lambda self,other: Concat(other, self)
-Parameter.__add__ = lambda self,other: Shifted(self,other)
-Parameter.__radd__ = lambda self,other: Shifted(other, self)
 
 
 class StructArray(Expression):

--- a/src/collections.py
+++ b/src/collections.py
@@ -31,7 +31,6 @@ class StructArray(Expression):
         #store the formats for each argument
         formats = []
         for a in args:
-            a = a.squeeze(1)
             size = a.shape[self.axis]
             fmt = (a.dtype, size)
             formats.append(fmt)

--- a/src/collections.py
+++ b/src/collections.py
@@ -38,5 +38,5 @@ class StructArray(Expression):
             fmt = (a.dtype, size)
             formats.append(fmt)
         dtype = np.dtype({'names':list(self.parameters),'formats':formats})
-        result = np.concatenate(args, axis=self.axis).squeeze()
-        return result.view(dtype=dtype)
+        result = np.concatenate(args, axis=self.axis)
+        return result.view(dtype=dtype).squeeze()

--- a/src/integration.py
+++ b/src/integration.py
@@ -2,7 +2,21 @@ import vegas
 from .base import Expression
 import numpy as np
 from gvar import gvar
+   
+def integral_naiive(e: Expression):
+    """naiive MC integration without vegas"""
+    def _run_integral(nitn=10, neval=1000, **kwargs):
+        v,w = expr.sample(neval*nitn), e.factor
+        #reshape for each iteration to be a in a separate row
+        v = v.reshape((neval,nitn, *v.shape[1:]))
+        w = w.reshape((neval,nitn, *w.shape[1:]))
+        
+        wv = np.squeeze(v)*np.squeeze(w)
+        
+        result = np.prod(np.diff(e.input_limits)) * np.sum(wv, axis=0)/v.shape[0]
+        return gvar.gvar(result.mean(axis=0),result.std(axis=0))
 
+    
 def integral(e: Expression):
     """decorator for turning expression into integral"""
     def _integrand(x):
@@ -11,14 +25,14 @@ def integral(e: Expression):
             return {key:np.squeeze(value)*np.squeeze(e.factor) for key,value in result.items()}
         else:
             return np.squeeze(result) * np.squeeze(e.factor)
-        
+
     if(len(e)>0):
         integrator = vegas.Integrator(e.input_limits)
         def _run_integral(adapt=False, **vegas_parameters):
             if adapt:
                 #run the calculation without storing the result
                 integrator(vegas.lbatchintegrand(_integrand), nitn=10, neval=1000)
-            return integrator(vegas.lbatchintegrand(_integrand), **vegas_parameters)
+            return integrator(vegas.lbatchintegrand(_integrand), **vegas_parameters, adapt=False)
         return _run_integral
     
     else:    
@@ -27,3 +41,4 @@ def integral(e: Expression):
         
         return _just_calculate
         
+    

--- a/src/integration.py
+++ b/src/integration.py
@@ -6,7 +6,7 @@ from gvar import gvar
 def integral_naiive(e: Expression):
     """naiive MC integration without vegas"""
     def _run_integral(nitn=10, neval=1000, **kwargs):
-        v,w = expr.sample(neval*nitn), e.factor
+        v,w = e.sample(neval*nitn), e.factor
         #reshape for each iteration to be a in a separate row
         v = v.reshape((neval,nitn, *v.shape[1:]))
         w = w.reshape((neval,nitn, *w.shape[1:]))

--- a/src/sampling.py
+++ b/src/sampling.py
@@ -1,0 +1,51 @@
+from .base import Parameter
+import numpy as np
+#adds  sampling method to the parameter
+def _sample_with_normalized_factor(self:Parameter, size=1, iter_max=10):
+        """Generate sample of the given size, but applying the factor as survival probability, 
+        i.e. randomly dropping the values with low factor.
+
+        Note: this process is iterative (it might need to generate several samples), and several times slower than regular :meth:`sample` method
+        """
+        #start with the sample of size N
+        selected = []
+        N = size
+        N_generate = int(N*2) #the size of next sample to generate
+        for it in range(iter_max):
+            sample, factor = self.sample(N_generate), self.factor
+            #expand factor
+            factor = factor*np.ones(shape=(N_generate))
+            if it==0:
+                if np.min(self.factor)==np.max(self.factor):
+                    #the factor is equal for all values, so just return this sample
+                    return sample[:N]
+                    
+            random = np.random.uniform(size=len(sample))
+            if it==0:
+                the_sample = sample
+                the_factor = factor
+                the_random = random
+            else:
+                the_sample = np.append(the_sample, sample, axis=0)
+                the_factor = np.append(the_factor, factor, axis=0)
+                the_random = np.append(the_random, random, axis=0)
+            #apply the selection
+            selected = (the_random*the_factor.max()) < the_factor
+            N_selected = selected.sum()
+            print(f"Iteration #{it}: generated {N_generate} -> selected={N_selected}/{len(the_factor)}")
+            if N_selected>=N:
+                self.factor = np.ones(N)*N/len(the_factor)
+                return the_sample[selected][:N]
+            else:
+                prob = N_selected/len(the_sample) #estimated selection probability
+                #now decide how many items to generate
+                # N = prob*(N_total) = N_selected + prob*N_generate =>
+                N_generate = (N-N_selected)/prob
+                #additional 20% to avoid making small iterations
+                N_generate *= 1.2
+                #make sure we don't make a sample too small or too large
+                N_generate = np.clip(N_generate, N/100, N*1000)
+                N_generate = np.asarray(np.ceil(N_generate), dtype=int)
+        raise RuntimeError(f"Maximum iterations ({iter_max}) reached. Generated only {sum(selected)} points of {N} requested")
+
+Parameter.sample_with_factor = _sample_with_normalized_factor

--- a/src/vector.py
+++ b/src/vector.py
@@ -35,7 +35,7 @@ class Vector:
     xyz:Uniform = Fixed([0,0,0])
     @staticmethod
     def __call__(xyz):
-        return xyz.reshape(xyz.shape[0],-1,3).view(vector)
+        return xyz.reshape(xyz.shape[0],-1,xyz.shape[-1]).view(vector)
 
 @expression
 class Scalar:
@@ -54,12 +54,3 @@ class Direction(Vector):
     def __call__(cos_theta:np.ndarray, phi:np.ndarray)->np.ndarray:
         sin_theta = np.sqrt(1-cos_theta**2)
         return np.stack([sin_theta*np.cos(phi),sin_theta*np.sin(phi), cos_theta], axis=-1).view(vector)
-
-
-@expression
-class PolarVector(Vector):
-    R:Uniform = 1
-    s:Direction = Direction()
-    @staticmethod
-    def __call__(R,s):
-        return R*s

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -1,0 +1,20 @@
+import numpy as np
+import vegas_params as vp
+
+def test_StructArray_from_uniforms_and_fixed_values():
+    e = vp.collections.StructArray(x = vp.Uniform([0,1]), y=42, z=vp.Uniform([[0,0],[10,20]]))
+    s = e.sample(100)
+    assert s.shape == (100,)
+    assert s['x'].shape == (100,1)
+    assert np.all(s['x']<=1) & np.all(s['x']>=0)
+    assert s['y'].shape == (100,1)
+    assert np.all(s['y']==42)
+    assert s['z'].shape == (100,2)
+    assert np.all(s['z']>=0) & np.all(s['z'][:,0]<=10) & np.all(s['z'][:,1]<=20)
+
+def test_StructArray_from_vectors_and_scalars():
+    e = vp.collections.StructArray(s = vp.Scalar(vp.Uniform([0,1])), v=vp.Vector([0,0,1]))
+    s = e.sample(100)
+    assert s.shape == (100,)
+    assert s['s'].shape == (100,1)
+    assert s['v'].shape == (100,3)


### PR DESCRIPTION
* Adding a method `Parameter.sample_with_factor`: it allows to generate the samples with uniform factor, dropping the values with low factor.
* Adding `collections.StructArray` - an expression to build structured arrays from given parameters
* Added `vp.integration.integrate_naiive` for a simple integral calculation without vegas
* Reworking the way Expressions are created from classes and functions. Now default values of expression parameters can be specified in the function arguments:
```python
@vp.expression
def foo(x = vp.Uniform([0,100])):
   ...
```
- [x] Add tests for StructArray
- [x] Add documentation for StructArray
- [ ] Add tests for sampling
- [x] Add documentation for sampling