### PR TITLE
Ash/add expression utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,38 @@ def product(x,y):
 It's possible to also add the Jacobian factor to the expression. 
 To do this, add `self` argument to function and set `serlf.factor` to needed value. This value will be multiplied by the expression value during the integration.
 
+### 3.5 Expression utilities
+There are several utilities to modify the existing expression:
+* `vegas_params.utils.factor`: create an expression with multiplication factor, which will affect the final integral. 
+* `vegas_params.utils.total`: create an expression with return value=1, to make
+* `vegas_params.utils.normalize_integral`: create expression with the total integral normalized to given value.
+
+The usage of these expressions is illustrated by this example:
+```python
+>> import vegas_params as vp
+>> from vegas_params.utils import total, factor, normalize_integral
+>> x = vp.Uniform([-1,1])
+>> ix =vp.integral(x)(nitn=10) 
+>> print(f"\\int x dx = {ix}")
+
+>> ix = vp.integral(total(y))(nitn=10)
+>> print(f"\\int dx = {ix}")
+
+>> xf = factor(x, value=5)
+>> ixf = vp.integral(total(xf))(nitn=10)
+>> print(f"5*\\int dx = {ixf}")
+
+>> xn = normalize_integral(value=123)(x)
+>> ixn = vp.integral(total(xn))(nitn=10)
+>> print(f"N*\\int dx = {ixn}")
+
+\int x dx = -7.1(9.3)e-05
+\int dx = 2.000000000000000(47)
+5*\int dx = 10.00000000000000(24)
+Normalizing norm=2.000000000000000(47) to value=123 with norm_factor=61.5
+N*\int dx = 122.9999999999997(29)
+```
+
 ## 4. Sampling
 
 The `vegas_params` expressions and parameters can be used not only for integration, but as random value generators.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.2.1"
-from . import base, vector, collections, sampling
+from . import base, vector, collections, sampling, utils
 from .base import Uniform, Fixed, FromDistribution, Expression, expression
 from .vector import Direction, Vector, Scalar
 from .integration import integral

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 from . import base, vector, collections, sampling, utils
 from .base import Uniform, Fixed, FromDistribution, Expression, expression
 from .vector import Direction, Vector, Scalar

--- a/src/base.py
+++ b/src/base.py
@@ -61,10 +61,25 @@ class Expression(Uniform):
     """Complex expression of the given input parameters"""
     def __init__(self, **parameters):
         self.parameters = {name:_make_parameter(par) for name,par in  parameters.items()} 
-    def __getitem__(self, name:str)->Parameter:
-        return self.parameters[name]
-    def __setitem__(self, name:str, value):
-        self.parameters[name] = _make_parameter(value)
+    
+    def __getitem__(self, key:str)->Parameter:
+        """Get the parameter of this expression 
+        (key can be a dot separated path, to access children expressions' parameters)"""
+        expr = self
+        for token in key.split('.'):
+            expr = expr.parameters[token]
+        return expr
+    
+    def __setitem__(self, key:str, value):
+        """Set the subexpression to a given value
+        (key can be a dot separated path, to access children expressions' parameters)
+        """
+        try:
+            path, key = key.rsplit('.',1)
+            expr = self[path]
+        except ValueError:
+            expr = self
+        expr.parameters[key] = _make_parameter(value)
         
     @property
     def input_limits(self):

--- a/src/base.py
+++ b/src/base.py
@@ -77,6 +77,8 @@ class Expression(Uniform):
         factor_from_parameters = 1
         for name,par in self.parameters.items():
             par_values[name] = par.__construct__(x[:,n:n+len(par)])
+            if np.ndim(par.factor)>0:
+                assert par.factor.shape == (x.shape[0],), f"for expr {name=} {par.factor.shape=}: {par.factor}"
             factor_from_parameters *= par.factor
             n+=len(par)
         #run the final evaluation function

--- a/src/integration.py
+++ b/src/integration.py
@@ -40,7 +40,7 @@ def integral(e: Expression):
                 If adapt is Expression - use it for adaptation run. 
                 This allows to run adaptation on a smoother variant of a function.
             **vegas_parameters: dict
-                Keyword parameters for the vegas run 
+                Keyword parameters for the vegas.Integrator 
                 (see https://vegas.readthedocs.io/en/latest/vegas.html#vegas.Integrator)
             """
             if adapt==True:

--- a/src/integration.py
+++ b/src/integration.py
@@ -26,10 +26,23 @@ def make_integrand(e: Expression):
     return _integrand
     
 def integral(e: Expression):
-    """decorator for turning expression into integral"""
+    """decorator for turning expression into integral function"""
     if(len(e)>0):
         integrator = vegas.Integrator(e.input_limits)
-        def _run_integral(adapt=False, **vegas_parameters):
+        def _run_integral(adapt:bool|Expression=False, **vegas_parameters):
+            """Run the integration calculation. 
+            Parameters:
+            -----------
+            adapt: bool or Expression
+                Defines how to make vegas "adaptation" run - letting vegas to study the integrable function.
+                If adapt=False (default) - no adaptation run
+                If adapt=True - make adaptation run on this expression
+                If adapt is Expression - use it for adaptation run. 
+                This allows to run adaptation on a smoother variant of a function.
+            **vegas_parameters: dict
+                Keyword parameters for the vegas run 
+                (see https://vegas.readthedocs.io/en/latest/vegas.html#vegas.Integrator)
+            """
             if adapt==True:
                 #adapt on the same function
                 adapt=e

--- a/src/integration.py
+++ b/src/integration.py
@@ -16,28 +16,33 @@ def integral_naiive(e: Expression):
         result = np.prod(np.diff(e.input_limits)) * np.sum(wv, axis=0)/v.shape[0]
         return gvar.gvar(result.mean(axis=0),result.std(axis=0))
 
+def make_integrand(e: Expression):
+    def _integrand(x):
+            result = e.__construct__(x)
+            if isinstance(result, dict):
+                return {key:np.squeeze(value)*np.squeeze(e.factor) for key,value in result.items()}
+            else:
+                return np.squeeze(result) * np.squeeze(e.factor)
+    return _integrand
     
 def integral(e: Expression):
     """decorator for turning expression into integral"""
-    def _integrand(x):
-        result = e.__construct__(x)
-        if isinstance(result, dict):
-            return {key:np.squeeze(value)*np.squeeze(e.factor) for key,value in result.items()}
-        else:
-            return np.squeeze(result) * np.squeeze(e.factor)
-
     if(len(e)>0):
         integrator = vegas.Integrator(e.input_limits)
         def _run_integral(adapt=False, **vegas_parameters):
-            if adapt:
+            if adapt==True:
+                #adapt on the same function
+                adapt=e
+            if adapt!=False:
                 #run the calculation without storing the result
-                integrator(vegas.lbatchintegrand(_integrand), nitn=10, neval=1000)
-            return integrator(vegas.lbatchintegrand(_integrand), **vegas_parameters, adapt=False)
+                assert isinstance(adapt, Expression), f"adapt must be an Expression object, not {type(adapt)}"
+                integrator(vegas.lbatchintegrand(make_integrand(adapt)), nitn=10, neval=1000)
+            return integrator(vegas.lbatchintegrand(make_integrand(e)), **vegas_parameters, adapt=False)
         return _run_integral
     
     else:    
         def _just_calculate(**vegas_parameters):
-            return gvar(_integrand(np.empty(shape=(1,0))))
+            return gvar(make_integrand(e)(np.empty(shape=(1,0))))
         
         return _just_calculate
         

--- a/src/integration.py
+++ b/src/integration.py
@@ -29,7 +29,7 @@ def integral(e: Expression):
     """decorator for turning expression into integral function"""
     if(len(e)>0):
         integrator = vegas.Integrator(e.input_limits)
-        def _run_integral(adapt:bool|Expression=False, **vegas_parameters):
+        def _run_integral(adapt=False, **vegas_parameters):
             """Run the integration calculation. 
             Parameters:
             -----------

--- a/src/utils.py
+++ b/src/utils.py
@@ -95,4 +95,24 @@ def save_input(name='input'):
         return save_input()(name)
     else:
         return decorator
-    
+
+from .integration import integral
+from .base import expression,Expression, Uniform
+#several of useful expressions
+@expression
+def factor(self, expr:Expression, value:Uniform):
+    """apply the normalization factor to the expression"""
+    self.factor = value
+    return expr
+
+@expression
+def total(expr:Expression):
+    """throw away the calculated value, so we can calc integral of expression parameter space"""
+    return np.ones(len(expr))
+
+def normalize(expr:Expression, value=1, **vegas_kwargs):
+    """return the expression with normalized factor"""
+    #first calculate the total integral
+    norm = integral(total(expr))(**vegas_kwargs)
+    #return the one with corrected factor
+    return factor(expr, value/norm.mean)

--- a/src/utils.py
+++ b/src/utils.py
@@ -102,7 +102,7 @@ from .base import expression,Expression, Uniform
 @expression
 def factor(self, expr:Expression, value:Uniform):
     """apply the normalization factor to the expression"""
-    self.factor = value
+    self.factor = value.squeeze()
     return expr
 
 @expression
@@ -110,9 +110,13 @@ def total(expr:Expression):
     """throw away the calculated value, so we can calc integral of expression parameter space"""
     return np.ones(len(expr))
 
-def normalize(expr:Expression, value=1, **vegas_kwargs):
-    """return the expression with normalized factor"""
-    #first calculate the total integral
-    norm = integral(total(expr))(**vegas_kwargs)
-    #return the one with corrected factor
-    return factor(expr, value/norm.mean)
+def normalize_integral(value=1, **vegas_kwargs):
+    """decorator to create the expression with normalized factor"""
+    def _wrapper(expr:Expression):
+        #first calculate the total integral
+        norm = integral(total(expr))(**vegas_kwargs)
+        norm_factor = value/norm.mean
+        print(f'Normalizing {norm=} to {value=} with {norm_factor=}')
+        #return the one with corrected factor
+        return factor(expr, norm_factor)
+    return _wrapper

--- a/test/test_integrals.py
+++ b/test/test_integrals.py
@@ -1,37 +1,29 @@
 import numpy as np
-from vegas_params import expression, Uniform, Vector, Direction, Scalar, vector
-from vegas_params import integral
+import vegas_params as vp
 
 def assert_integral_is_close(e, value, precision=0.1):
-    x = integral(e)(nitn=30, neval=10000)
+    x = vp.integral(e)(nitn=30, neval=10000)
     assert np.abs(x.mean - value) < value*precision
     
 def test_1d_constant_integral():
     #test linear integral
-    @expression(x=Uniform([0,5]))
+    @vp.expression(x=vp.Uniform([0,5]))
     def constant(x):
         return np.ones(x.shape[0])
 
     assert_integral_is_close(constant,5)
 
 def test_2d_constant_integral():
-    @expression(x=Uniform([0,5]), y=Uniform([0,5]))
+    @vp.expression(x=vp.Uniform([0,5]), y=vp.Uniform([0,5]))
     def constant(x,y):
         return np.ones(x.shape[0])
 
     assert_integral_is_close(constant,25)
 
 def test_Gaussian_integral():
-    @expression(x=Uniform([-100,100]))
-    def gaussian(x):
-        return np.exp(-x**2)
-
-    assert_integral_is_close(gaussian, np.sqrt(np.pi))
-
-def test_Gaussian_integral():
     #test linear integral with factor
     
-    @expression(x=Uniform([-100,100]))
+    @vp.expression(x=vp.Uniform([-100,100]))
     def gaussian(x):
         return np.exp(-x**2)
 
@@ -42,7 +34,7 @@ def test_Spherical_integral_simple():
         return np.ones(r.shape[0])
     #test spherical integral with factor
     Rsphere=10
-    @expression(R=Scalar(Uniform([0,Rsphere])), direction=Direction())
+    @vp.expression(R=vp.Scalar(vp.Uniform([0,Rsphere])), direction=vp.Direction())
     def density(R, direction):
         r = R*direction
         return R**2
@@ -51,18 +43,38 @@ def test_Spherical_integral_simple():
 
 def test_Spherical_integral():
     #test spherical integral with factor
-    @expression
+    @vp.expression
     class Spherical:
-        R:Scalar = Scalar(Uniform([0,1]))
-        s:Direction = Direction()
+        R:vp.Scalar = vp.Scalar(vp.Uniform([0,1]))
+        s:vp.Direction = vp.Direction()
         def __call__(self,R,s):
             self.factor = R**2
             return R*s
 
     Rsphere=10
     
-    @expression(r=Spherical(R=Scalar(Uniform([0,Rsphere]))))
-    def density(r:vector):
+    @vp.expression(r=Spherical(R=vp.Scalar(vp.Uniform([0,Rsphere]))))
+    def density(r:vp.Vector):
         return np.ones(r.shape[0])
         
     assert_integral_is_close(density, 4/3*np.pi*Rsphere**3)
+
+def test_Spherical_integral_normalized():
+    #test spherical integral with factor
+    @vp.expression
+    class Spherical:
+        R:vp.Scalar = vp.Scalar(vp.Uniform([0,1]))
+        s:vp.Direction = vp.Direction()
+        def __call__(self,R,s):
+            self.factor = R**2
+            return R*s
+
+    Rsphere=10
+
+    @vp.utils.normalize_integral(123)
+    @vp.expression(r=Spherical(R=vp.Scalar(vp.Uniform([0,Rsphere]))))
+    def density(r:vp.Vector):
+        return np.ones(r.shape[0])
+        
+    assert_integral_is_close(density, 123)
+

--- a/test/test_integrals.py
+++ b/test/test_integrals.py
@@ -97,12 +97,12 @@ def test_integral_with_external_adapt():
         return np.exp(-dr/radius).squeeze()
 
     #check that simple integral with standard adaptation gives us 0
-    i_default = vp.integral(sharp_function)(nitn=5, neval=1000, adapt=True)
+    i_default = vp.integral(sharp_function)(nitn=50, neval=10000, adapt=True)
     assert np.isclose(i_default.mean, 0)
 
     #check that simple integral with standard adaptation gives us 0
-    i_adapt = vp.integral(sharp_function)(nitn=5, neval=1000, adapt=soft_function)
+    i_adapt = vp.integral(sharp_function)(nitn=50, neval=10000, adapt=soft_function)
     I_expected = np.pi*radius**2
-    assert np.isclose(i_adapt.mean, I_expected, atol=1e-3)
+    assert np.isclose(i_adapt.mean, I_expected, rtol=1e-1)
     
     


### PR DESCRIPTION
* `vp.integration.integral`: now can receive `adapt=<expression>` argument, and the given expression will be used for adaptation
* `vp.utils`: new util expressions: 
  * `factor` to change the Jacobian factor of given expression
  * `total` to calculate integrals of complex expressions (better name? density?)
  * `normalize_integral` to normalize the total integral of expression to specific value
  
* Added test for `normalize_integral`

TODO:
-----
- [x] Add documentation for `adapt`
- [x] Add documentation for new utils
- [x] Add test for `adapt`
- [x] Update version